### PR TITLE
Fixed query string parsing error

### DIFF
--- a/coreModulePackages/query-string/index.js
+++ b/coreModulePackages/query-string/index.js
@@ -24,6 +24,11 @@ module.exports = {
       // Remove leading ?, #, & for some leniency so you can pass in location.search or
       // location.hash directly.
       string = string.trim().replace(/^[?#&]/, '');
+      
+      // Remove instances of 2 or more % characters to prevent decodeURIComponent errors
+      if (string.indexOf('%%') !== -1){
+            string.replace(/%%+/gi, '');
+      }
     }
     return querystring.parse(string);
   },


### PR DESCRIPTION
Loading a web page with 2 or more instances of the "%" character in the URL query string breaks multiple aspects of Launch functionality including the Adobe Analytics module (never fires main page view tracking call) as well as causing any query string parameter data elements to continuously output errors in the browser console (when Launch debug output to the console is enabled).

Example URL:
https://www.adobe.com/?utm_campaign=abc%%123%20%%hello%%%%&utm_source=search

Loading the URL above will result in the Adobe Analytics tracking call not firing on adobe.com and numerous errors will appear in the browser console (continuously) for all Launch data elements using the Core module's query string parameter data element functionality. Make sure to enable Launch debug mode  to see those errors.

## Pull Request Description

I added a simple regex string replace in reactorQueryString object to remove any occurrences of 2 or more "%" characters from the query string before the value is passed to the "query-string" module "decode" function which reactorQueryString proxies as the "parse" function.

## Motivation and Context

Adobe Analytics should ALWAYS be able to fire the main pageview tracking call, otherwise finding issues and errors related to malformed URL's like this is -extremely- difficult since they will not appear in reporting anywhere to alert business stakeholders of a potential problem.

## How Has This Been Tested?

Yes, it has been tested - the easiest way to see the issue and to test the fix is by including the "SDI Toolkit" Launch Extension on any website with Launch active because that particular extension exposes the reactor.queryString module outside of the reactor-turbine closure for normal usage from the global window context. 

Run the JS snippets below in the browser developer console to see the before/after behavior using the same regex string replacement that this pull request includes.

ERROR:
var badQueryString = "utm_campaign=abc%%123%20%%hello%%%%&utm_source=search";
_sdiToolkit.reactor.queryString.parse(badQueryString);

NO ERROR:
var badQueryString = "utm_campaign=abc%%123%20%%hello%%%%&utm_source=search";
_sdiToolkit.reactor.queryString.parse(badQueryString.replace(/%%+/gi, ''));

